### PR TITLE
Specify required Gst and GUdev versions

### DIFF
--- a/kazam/backend/gstreamer.py
+++ b/kazam/backend/gstreamer.py
@@ -23,6 +23,7 @@ import os
 import logging
 logger = logging.getLogger("GStreamer")
 
+import gi
 import tempfile
 import multiprocessing
 
@@ -31,6 +32,8 @@ import multiprocessing
 #
 os.environ["GST_DEBUG_DUMP_DOT_DIR"] = "/tmp"
 os.putenv("GST_DEBUG_DUMP_DOT_DIR", "/tmp")
+
+gi.require_version('Gst', '1.0')
 
 from gi.repository import GObject, Gst, GstVideo
 

--- a/kazam/backend/webcam.py
+++ b/kazam/backend/webcam.py
@@ -20,6 +20,9 @@
 #       MA 02110-1301, USA.
 
 import logging
+import gi
+
+gi.require_version('GUdev', '1.0')
 
 from gi.repository import GObject, GUdev
 


### PR DESCRIPTION
This patch fixes #19 wherein the versions for Gst and GUdev require specification.

Also added `import gi` to resolve  the **NameError: name 'gi' is not defined**
