### PR TITLE
Add X/Y offset settings for webcam

### DIFF
--- a/data/ui/preferences.ui
+++ b/data/ui/preferences.ui
@@ -20,6 +20,20 @@
     <property name="step_increment">1</property>
     <property name="page_increment">3</property>
   </object>
+  <object class="GtkAdjustment" id="adjustment_x_offset">
+    <property name="lower">0</property>
+    <property name="upper">10000</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+    <property name="page_size">0</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment_y_offset">
+    <property name="lower">0</property>
+    <property name="upper">10000</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+    <property name="page_size">0</property>
+  </object>
   <object class="GtkWindow" id="window">
     <property name="can_focus">False</property>
     <property name="halign">start</property>
@@ -1249,7 +1263,73 @@ Server URL in the entry fields.</property>
                     <property name="height">1</property>
                   </packing>
                 </child>
-              </object>
+                <child>
+                  <object class="GtkLabel" id="label_x_offset">
+                    <property name="width_request">150</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="xalign">1</property>
+                    <property name="label" translatable="yes">X-offset:</property>
+                    <property name="justify">right</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">4</property>
+                    <property name="width">1</property>
+                    <property name="height">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="spinbutton_webcam_preview_x_offset">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="halign">start</property>
+                    <property name="adjustment">adjustment_x_offset</property>
+                    <property name="numeric">True</property>
+                    <signal name="value-changed" handler="cb_webcam_preview_x_offset_changed" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">4</property>
+                    <property name="width">1</property>
+                    <property name="height">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label_y_offset">
+                    <property name="width_request">150</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="xalign">1</property>
+                    <property name="label" translatable="yes">Y-offset:</property>
+                    <property name="justify">right</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">5</property>
+                    <property name="width">1</property>
+                    <property name="height">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="spinbutton_webcam_preview_y_offset">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="halign">start</property>
+                    <property name="adjustment">adjustment_y_offset</property>
+                    <property name="numeric">True</property>
+                    <signal name="value-changed" handler="cb_webcam_preview_y_offset_changed" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">5</property>
+                    <property name="width">1</property>
+                    <property name="height">1</property>
+                  </packing>
+                </child>
+             </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>

--- a/kazam/backend/config.py
+++ b/kazam/backend/config.py
@@ -62,6 +62,8 @@ class KazamConfig(object):
                          "webcam_source":          "0",
                          "webcam_show_preview":    "True",
                          "webcam_preview_pos":     "1",
+                         "webcam_preview_x_offset": "0",
+                         "webcam_preview_y_offset": "0",
                          "webcam_resolution":      "0",
                          "capture_speakers_w":     "False",
                          "capture_microphone_w":   "False",

--- a/kazam/backend/gstreamer.py
+++ b/kazam/backend/gstreamer.py
@@ -486,7 +486,9 @@ class Screencast(GObject.GObject):
             # Setup camera preview window
             self.cam_window = WebcamWindow(CAM_RESOLUTIONS[prefs.webcam_resolution][0],
                                            CAM_RESOLUTIONS[prefs.webcam_resolution][1],
-                                           prefs.webcam_preview_pos)
+                                           prefs.webcam_preview_pos,
+                                           prefs.webcam_preview_x_offset,
+                                           prefs.webcam_preview_y_offset)
 
             self.cam_xid = self.cam_window.xid
 
@@ -698,7 +700,9 @@ class GWebcam(GObject.GObject):
 
         self.cam_window = WebcamWindow(CAM_RESOLUTIONS[prefs.webcam_resolution][0],
                                        CAM_RESOLUTIONS[prefs.webcam_resolution][1],
-                                       prefs.webcam_preview_pos)
+                                       prefs.webcam_preview_pos,
+                                       prefs.webcam_preview_x_offset,
+                                       prefs.webcam_preview_y_offset)
 
         self.cam_xid = self.cam_window.xid
 

--- a/kazam/backend/prefs.py
+++ b/kazam/backend/prefs.py
@@ -124,6 +124,8 @@ class Prefs():
         self.webcam_sources = {}
         self.webcam_show_preview = True
         self.webcam_preview_pos = 1
+        self.webcam_preview_x_offset = 0
+        self.webcam_preview_y_offset = 0
         self.webcam_resolution = 0
 
         self.yt_stream = ''
@@ -270,6 +272,8 @@ class Prefs():
 
         self.webcam_show_preview = self.config.getboolean("main", "webcam_show_preview")
         self.webcam_preview_pos = int(self.config.get("main", "webcam_preview_pos"))
+        self.webcam_preview_x_offset = int(self.config.get("main", "webcam_preview_x_offset"))
+        self.webcam_preview_y_offset = int(self.config.get("main", "webcam_preview_y_offset"))
         self.webcam_resolution = int(self.config.get("main", "webcam_resolution"))
 
         self.capture_keys = self.config.getboolean("main", "capture_keys")
@@ -349,6 +353,8 @@ class Prefs():
 
         self.config.set("main", "webcam_show_preview", self.webcam_show_preview)
         self.config.set("main", "webcam_preview_pos", self.webcam_preview_pos)
+        self.config.set("main", "webcam_preview_x_offset", self.webcam_preview_x_offset)
+        self.config.set("main", "webcam_preview_y_offset", self.webcam_preview_y_offset)
         self.config.set("main", "webcam_resolution", self.webcam_resolution)
 
         self.config.set("main", "yt_stream", self.yt_stream)

--- a/kazam/frontend/preferences.py
+++ b/kazam/frontend/preferences.py
@@ -205,6 +205,9 @@ class Preferences(GObject.GObject):
 
         self.combobox_webcam.set_active(prefs.webcam_source)
         self.combobox_webcam_preview.set_active(prefs.webcam_preview_pos)
+        self.spinbutton_webcam_preview_x_offset.set_value(prefs.webcam_preview_x_offset)
+        self.spinbutton_webcam_preview_y_offset.set_value(prefs.webcam_preview_y_offset)
+
         self.combobox_webcam_resolution.set_active(prefs.webcam_resolution)
 
         if prefs.webcam_show_preview:
@@ -414,6 +417,14 @@ class Preferences(GObject.GObject):
         logger.debug("Webcam preview position set to:")
         prefs.webcam_preview_pos = self.combobox_webcam_preview.get_active()
         logger.debug("  {}".format(prefs.webcam_preview_pos))
+
+    def cb_webcam_preview_x_offset_changed(self, widget):
+        prefs.webcam_preview_x_offset = widget.get_value_as_int()
+        logger.debug("Webcam X-offset position set to: {0}".format(prefs.webcam_preview_x_offset))
+
+    def cb_webcam_preview_y_offset_changed(self, widget):
+        prefs.webcam_preview_y_offset = widget.get_value_as_int()
+        logger.debug("Webcam Y-offset position set to: {0}".format(prefs.webcam_preview_y_offset))
 
     def cb_switch_webcam_preview(self, widget, user_data):
         prefs.webcam_show_preview = widget.get_active()

--- a/kazam/frontend/window_webcam.py
+++ b/kazam/frontend/window_webcam.py
@@ -27,7 +27,7 @@ from kazam.backend.prefs import *
 
 
 class WebcamWindow(GObject.GObject):
-    def __init__(self, width, height, position):
+    def __init__(self, width, height, position, x_offset, y_offset):
         super(WebcamWindow, self).__init__()
         logger.debug("Initializing Webcam window.")
 
@@ -46,16 +46,16 @@ class WebcamWindow(GObject.GObject):
         self.window.set_size_request(width, height)
         if position == CAM_PREVIEW_TL:
             self.window.set_gravity(Gdk.Gravity.NORTH_WEST)
-            self.window.move(screen['x'], screen['y'])
+            self.window.move(screen['x'] + x_offset, screen['y'] + y_offset)
         elif position == CAM_PREVIEW_TR:
             self.window.set_gravity(Gdk.Gravity.NORTH_EAST)
-            self.window.move(screen['x'] + screen['width'] - width, screen['y'])
+            self.window.move(screen['x'] + screen['width'] - width - x_offset, screen['y'] + y_offset)
         elif position == CAM_PREVIEW_BR:
             self.window.set_gravity(Gdk.Gravity.SOUTH_EAST)
-            self.window.move(screen['x'] + screen['width'] - width, screen['y'] + screen['height'] - height)
+            self.window.move(screen['x'] + screen['width'] - width - x_offset, screen['y'] + screen['height'] - height - y_offset)
         elif position == CAM_PREVIEW_BL:
             self.window.set_gravity(Gdk.Gravity.SOUTH_WEST)
-            self.window.move(screen['x'], screen['y'] + screen['height'] - height)
+            self.window.move(screen['x'] + x_offset, screen['y'] + screen['height'] - height - y_offset)
         else:
             pass
 


### PR DESCRIPTION
Allows more control over webcam preview position, particularly nice in situations with very large monitors.

Both X and Y offset will offset the the preview from the corner it's set to, towards the center of the screen