### PR TITLE
Fix: StatusIcon menu position.

### DIFF
--- a/kazam/frontend/indicator.py
+++ b/kazam/frontend/indicator.py
@@ -244,8 +244,8 @@ except ImportError:
                 self.indicator.set_visible(False)
 
         def cb_indicator_activate(self, widget):
-            def position(menu, widget):
-                return (Gtk.StatusIcon.position_menu(self.menu, widget))
+            def position(x, y, push_in, user_data):
+                return (Gtk.StatusIcon.position_menu(x, y, push_in, user_data))
             self.menu.popup(None, None, position, self.indicator, 0, Gtk.get_current_event_time())
 
         def cb_indicator_popup_menu(self, icon, button, time):


### PR DESCRIPTION
Hello, I tried to fix the status icon menu which is displayed far away from the tray icon when we click on it. I found in the logs that the signature of the position icon wasn't correct (that's probably why it was falling back to (0, 0) top left of the screen) and add the missing params as I could find them in the gtk doc https://docs.gtk.org/gtk3/callback.MenuPositionFunc.html 

Before:


https://github.com/henrywoo/kazam/assets/1866809/1144cd70-f1b5-4f9c-a6a6-ec5b7dd9bb07


After:



https://github.com/henrywoo/kazam/assets/1866809/d6bf1556-2138-4d4f-865a-43d944ca1874

