### PR TITLE
Closes #38: fix file chooser

### DIFF
--- a/kazam/frontend/preferences.py
+++ b/kazam/frontend/preferences.py
@@ -362,7 +362,7 @@ class Preferences(GObject.GObject):
             self.entry_autosave_video.set_sensitive(False)
 
     def cb_filechooser_video(self, widget):
-        prefs.autosave_video_dir = self.filechooser_video.get_current_folder()
+        prefs.autosave_video_dir = self.filechooser_video.get_filename()
         logger.debug("Autosave video folder set to: {0}".format(prefs.autosave_video_dir))
 
     def cb_entry_autosave_video(self, widget):
@@ -398,7 +398,7 @@ class Preferences(GObject.GObject):
             self.entry_autosave_picture.set_sensitive(False)
 
     def cb_filechooser_picture(self, widget):
-        prefs.autosave_picture_dir = self.filechooser_picture.get_current_folder()
+        prefs.autosave_picture_dir = self.filechooser_picture.get_filename()
         logger.debug("Autosave picture folder set to: {0}".format(prefs.autosave_picture_dir))
 
     def cb_entry_autosave_picture(self, widget):


### PR DESCRIPTION
# What is the proposed fix to #38?

We use `GtkFileChooserButton`'s `get_filename` method instead of its `get_current_folder` method. This way, a folder is selected by the user.

# What is the app's behavior, when we apply the same steps as in #38 ?

As shown below, the app behaves as expected.

### 1. Run `kazam` and open settings

![0_settings](https://github.com/henrywoo/kazam/assets/58120903/93f9872d-c6e1-4d98-ad1f-ef358cfffd9d)

### 2. Take a screencast

It is saved in `/home/loic/Videos`, as expected:

![1_screencast](https://github.com/henrywoo/kazam/assets/58120903/5b9ccdd2-a784-4998-98e7-09d0fcda1dbe)

### 3. Change the output folder

We change it to `/home/loic/Downloads` in this example; notice how `kazam`'s output says the expected message - `Autosave video folder set to: /home/loic/Downloads`:

![2_select_downloads](https://github.com/henrywoo/kazam/assets/58120903/293a13c6-2236-435f-9ca9-4b67b2fb3b2e)

### 4. Take a screencast

The screencast appears in the expected directory (`/home/loic/Downloads`):

![3_works_censored](https://github.com/henrywoo/kazam/assets/58120903/e09729c0-9e50-4446-98c5-f657ae4a3890)

### 5. Switch to the screenshot pane

![4_screenshot](https://github.com/henrywoo/kazam/assets/58120903/5edde480-7924-41d1-940a-30f8f55301c5)

### 6. Take a screenshot

The screenshot appears in `/home/loic/Videos`, as expected:

![5_screenshot](https://github.com/henrywoo/kazam/assets/58120903/712ef185-228b-4d26-85d7-0e8ecf80881d)

### 7. Select an output directory

We change it to `/home/loic/Downloads` in this example; notice how `kazam`'s output says the expected message - `Autosave picture folder set to: /home/loic/Downloads`:

![6_select_downloads](https://github.com/henrywoo/kazam/assets/58120903/f1412b7b-31a6-4f15-89dc-7f27f2017433)


### 8. Take a screenshot

The screenshot appears in the expected directory (`/home/loic/Downloads`):

![7_works_censored](https://github.com/henrywoo/kazam/assets/58120903/8a862bd0-249d-4b97-8f17-3f38c3393a51)

# Output of running ./kazam --debug when executing steps above

[Click here](https://github.com/henrywoo/kazam/files/14000666/output_my_commit.txt) to see the output.