### PR TITLE
add support for screen scaling

### DIFF
--- a/kazam/backend/gstreamer.py
+++ b/kazam/backend/gstreamer.py
@@ -154,7 +154,11 @@ class Screencast(GObject.GObject):
                 height = CAM_RESOLUTIONS[prefs.webcam_resolution][1]
                 endx = CAM_RESOLUTIONS[prefs.webcam_resolution][0] - 1
                 endy = CAM_RESOLUTIONS[prefs.webcam_resolution][1] - 1
-
+        scale = self.video_source['scale']
+        startx = int(startx * scale)
+        starty = int(starty * scale)
+        endx = int(endx * scale)
+        endy = int(endy * scale)
         #
         # H264 requirement is that video dimensions are divisible by 2.
         # If they are not, we have to get rid of that extra pixel.

--- a/kazam/backend/prefs.py
+++ b/kazam/backend/prefs.py
@@ -403,15 +403,18 @@ class hw:
 
             for i in range(self.default_screen.get_n_monitors()):
                 rect = self.default_screen.get_monitor_geometry(i)
-                self.logger.debug("  Monitor {0} - X: {1}, Y: {2}, W: {3}, H: {4}".format(i,
+                scale = self.default_screen.get_monitor_scale_factor(i)
+                self.logger.debug("  Monitor {0} - X: {1}, Y: {2}, W: {3}, H: {4}, scale: {5}".format(i,
                                                                                           rect.x,
                                                                                           rect.y,
                                                                                           rect.width,
-                                                                                          rect.height))
+                                                                                          rect.height,
+                                                                                          scale))
                 self.screens.append({"x": rect.x,
                                      "y": rect.y,
                                      "width": rect.width,
-                                     "height": rect.height})
+                                     "height": rect.height,
+                                     "scale": scale})
 
             if self.default_screen.get_n_monitors() > 1:
                 self.combined_screen = {"x": 0, "y": 0,

--- a/kazam/backend/prefs.py
+++ b/kazam/backend/prefs.py
@@ -417,11 +417,13 @@ class hw:
                                      "scale": scale})
 
             if self.default_screen.get_n_monitors() > 1:
+                scale = self.default_screen.get_monitor_scale_factor(0)
                 self.combined_screen = {"x": 0, "y": 0,
                                         "width": self.default_screen.get_width(),
-                                        "height": self.default_screen.get_height()}
-                self.logger.debug("  Combined - X: 0, Y: 0, W: {0}, H: {1}".format(self.default_screen.get_width(),
-                                                                                   self.default_screen.get_height()))
+                                        "height": self.default_screen.get_height(),
+                                        "scale": scale}
+                self.logger.debug("  Combined - X: 0, Y: 0, W: {0}, H: {1}, scale: {2}".format(self.default_screen.get_width(),
+                                                                                   self.default_screen.get_height(), scale))
             else:
                 self.combined_screen = None
 


### PR DESCRIPTION
I added the support of screen scaling by readomg `scale = self.default_screen.get_monitor_scale_factor(i)`, which works well on my computer (Ubuntu 22.04.4 LTS x86_64, 6.5.0-45-generic, NVIDIA GeForce RTX 4060 Ti, **two 4k screens with scaling 200%**). Before that, the screen recording didn't not work properly.