### PR TITLE
Use modern AyatanaAppIndicator3

### DIFF
--- a/kazam/frontend/indicator.py
+++ b/kazam/frontend/indicator.py
@@ -150,7 +150,9 @@ class KazamSuperIndicator(GObject.GObject):
         self.emit("indicator-quit-request")
 
 try:
-    from gi.repository import AppIndicator3
+    import gi
+    gi.require_version('AyatanaAppIndicator3', '0.1')
+    from gi.repository import AyatanaAppIndicator3 as AppIndicator3
 
     class KazamIndicator(KazamSuperIndicator):
 


### PR DESCRIPTION
To make great Kazam v2 more functional I have just switched it to Ayatana Indicators.

Please note that according to `rmadison gir1.2-appindicator3-0.1`

```
$ rmadison gir1.2-appindicator3-0.1
gir1.2-appindicator3-0.1 | 0.4.92-7      | oldoldstable | amd64, arm64, armhf, i386
```

the mentioned package with old AppIndicator3 was last available in Debian 10, which reached EOL and is supported by ELTS, so it is probably not popular today.